### PR TITLE
feat: Implement product deletion in admin section

### DIFF
--- a/admin/product_delete.php
+++ b/admin/product_delete.php
@@ -1,0 +1,74 @@
+<?php
+session_start();
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../includes/db.php';
+
+// Admin authentication check
+if (!isset($_SESSION['user_id']) || !isset($_SESSION['is_admin']) || !$_SESSION['is_admin']) {
+    $_SESSION['error_message'] = "Access denied.";
+    header("Location: " . SITE_URL . "login/");
+    exit;
+}
+
+$product_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+
+if ($product_id > 0) {
+    $conn = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    if ($conn->connect_error) {
+        die("Connection failed: " . $conn->connect_error);
+    }
+
+    // --- Step 1: Fetch all associated image filenames ---
+    $filenames_to_delete = [];
+
+    // Get main image
+    $stmt_main = $conn->prepare("SELECT image_url_main FROM products WHERE id = ?");
+    $stmt_main->bind_param("i", $product_id);
+    $stmt_main->execute();
+    $result_main = $stmt_main->get_result();
+    if ($row = $result_main->fetch_assoc()) {
+        if (!empty($row['image_url_main'])) {
+            $filenames_to_delete[] = $row['image_url_main'];
+        }
+    }
+    $stmt_main->close();
+
+    // Get additional images from product_media
+    $stmt_media = $conn->prepare("SELECT path_or_url FROM product_media WHERE product_id = ? AND media_type = 'image'");
+    $stmt_media->bind_param("i", $product_id);
+    $stmt_media->execute();
+    $result_media = $stmt_media->get_result();
+    while ($row = $result_media->fetch_assoc()) {
+        $filenames_to_delete[] = $row['path_or_url'];
+    }
+    $stmt_media->close();
+
+    // --- Step 2: Delete the product from the database ---
+    // The foreign key with ON DELETE CASCADE will handle deleting product_media records.
+    $stmt_delete = $conn->prepare("DELETE FROM products WHERE id = ?");
+    $stmt_delete->bind_param("i", $product_id);
+
+    if ($stmt_delete->execute()) {
+        // --- Step 3: If DB deletion is successful, delete the physical files ---
+        $upload_dir = __DIR__ . '/../uploads/';
+        foreach ($filenames_to_delete as $filename) {
+            $file_path = $upload_dir . $filename;
+            if (file_exists($file_path)) {
+                unlink($file_path);
+            }
+        }
+        $_SESSION['success_message'] = "Product (ID: $product_id) and all associated media have been deleted successfully.";
+    } else {
+        $_SESSION['error_message'] = "Failed to delete product.";
+    }
+    $stmt_delete->close();
+    $conn->close();
+
+} else {
+    $_SESSION['error_message'] = "Invalid product ID.";
+}
+
+// --- Step 4: Redirect back to the product list ---
+header("Location: " . SITE_URL . "admin/products/");
+exit;
+?>


### PR DESCRIPTION
This commit adds the functionality for administrators to delete products.

- A new script, `admin/product_delete.php`, has been created to handle the deletion logic.
- The script securely processes the deletion request, using prepared statements to interact with the database.
- Before deleting the product record from the `products` table, the script first identifies and deletes all associated physical image files (both the main image and any additional images) from the `uploads/` directory to prevent orphaned files.
- The corresponding records in the `product_media` table are deleted automatically via the `ON DELETE CASCADE` foreign key constraint.
- The admin is redirected back to the product list with a success or error message.