### PR TITLE
feat: Add landing page creation in admin panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Log files
+php_errors.log
+
+# Vendor directories
+/vendor/
+
+# User-uploaded content
+/uploads/
+
+# IDE and OS files
+.idea/
+.vscode/
+*.swp
+*~
+.DS_Store

--- a/admin/includes/header.php
+++ b/admin/includes/header.php
@@ -61,12 +61,13 @@ if ($active_section == 'index.php') $active_section = 'dashboard';
             </li>
 
             <li class="nav-item">
-                <a href="#contentSubmenu" data-bs-toggle="collapse" aria-expanded="<?php echo in_array($active_section, ['blog_posts', 'testimonials', 'content_edit']) ? 'true' : 'false'; ?>" class="nav-link dropdown-toggle <?php echo in_array($active_section, ['blog_posts', 'testimonials', 'content_edit']) ? '' : 'collapsed'; ?>">
+                <a href="#contentSubmenu" data-bs-toggle="collapse" aria-expanded="<?php echo in_array($active_section, ['blog_posts', 'testimonials', 'content_edit', 'landing_pages']) ? 'true' : 'false'; ?>" class="nav-link dropdown-toggle <?php echo in_array($active_section, ['blog_posts', 'testimonials', 'content_edit', 'landing_pages']) ? '' : 'collapsed'; ?>">
                     <i class="fas fa-file-alt"></i> Content
                 </a>
-                <ul class="collapse list-unstyled <?php echo in_array($active_section, ['blog_posts', 'testimonials', 'content_edit']) ? 'show' : ''; ?>" id="contentSubmenu" data-bs-parent="#sidebarAccordion">
+                <ul class="collapse list-unstyled <?php echo in_array($active_section, ['blog_posts', 'testimonials', 'content_edit', 'landing_pages']) ? 'show' : ''; ?>" id="contentSubmenu" data-bs-parent="#sidebarAccordion">
                     <li><a class="nav-link <?php echo ($active_section == 'blog_posts') ? 'active' : ''; ?>" href="<?php echo SITE_URL; ?>admin/blog_posts/">Blog Posts</a></li>
                     <li><a class="nav-link <?php echo ($active_section == 'testimonials') ? 'active' : ''; ?>" href="<?php echo SITE_URL; ?>admin/testimonials/">Testimonials</a></li>
+                    <li><a class="nav-link <?php echo ($active_section == 'landing_pages') ? 'active' : ''; ?>" href="<?php echo SITE_URL; ?>admin/landing_pages/">Landing Pages</a></li>
                     <li><a class="nav-link <?php echo ($active_section == 'content_edit' && ($_GET['page'] ?? '') == 'about') ? 'active' : ''; ?>" href="<?php echo SITE_URL; ?>admin/content_edit/?page=about">About Us Page</a></li>
                 </ul>
             </li>

--- a/admin/landing_pages/create.php
+++ b/admin/landing_pages/create.php
@@ -86,8 +86,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $landing_page_index = $new_dir . '/index.php';
     if (file_exists($landing_page_index)) {
         $content = file_get_contents($landing_page_index);
-        // Replace the placeholder product ID with the actual product ID
-        $content = preg_replace('/\$product_id\s*=\s*\d+;/', '$product_id = ' . $product_id . ';', $content);
+        // Replace the placeholder with the actual product ID
+        $content = str_replace('{{PRODUCT_ID}}', $product_id, $content);
         file_put_contents($landing_page_index, $content);
     }
 

--- a/admin/landing_pages/create.php
+++ b/admin/landing_pages/create.php
@@ -1,0 +1,102 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../includes/db.php';
+
+// Admin authentication check
+if (!isset($_SESSION['user_id']) || !isset($_SESSION['is_admin']) || !$_SESSION['is_admin']) {
+    $_SESSION['admin_error'] = "Access denied.";
+    header("Location: " . SITE_URL . "login/");
+    exit;
+}
+
+function sluggify($string) {
+    $string = preg_replace('~[^\pL\d]+~u', '-', $string);
+    $string = iconv('utf-8', 'us-ascii//TRANSLIT', $string);
+    $string = preg_replace('~[^-\w]+~', '', $string);
+    $string = trim($string, '-');
+    $string = preg_replace('~-+~', '-', $string);
+    $string = strtolower($string);
+    if (empty($string)) {
+        return 'n-a';
+    }
+    return $string;
+}
+
+function recursive_copy($src, $dst) {
+    if (is_dir($src)) {
+        if (!is_dir($dst)) {
+            mkdir($dst);
+        }
+        $files = scandir($src);
+        foreach ($files as $file) {
+            if ($file != "." && $file != "..") {
+                recursive_copy("$src/$file", "$dst/$file");
+            }
+        }
+    } else if (file_exists($src)) {
+        copy($src, $dst);
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $product_id = $_POST['product_id'] ?? null;
+
+    if (!$product_id) {
+        $_SESSION['error_message'] = "Please select a product.";
+        header("Location: index.php");
+        exit;
+    }
+
+    // Fetch product name to create a slug
+    $stmt = $conn->prepare("SELECT name FROM products WHERE id = ?");
+    $stmt->bind_param("i", $product_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $product = $result->fetch_assoc();
+
+    if (!$product) {
+        $_SESSION['error_message'] = "Product not found.";
+        header("Location: index.php");
+        exit;
+    }
+
+    $product_slug = sluggify($product['name']);
+    $new_dir = __DIR__ . '/../../' . $product_slug;
+
+    if (file_exists($new_dir)) {
+        $_SESSION['error_message'] = "A landing page for this product already exists: " . htmlspecialchars($product_slug);
+        header("Location: index.php");
+        exit;
+    }
+
+    $template_dir = __DIR__ . '/../../landing-page-template';
+
+    if (!is_dir($template_dir)) {
+        $_SESSION['error_message'] = "Landing page template directory not found.";
+        header("Location: index.php");
+        exit;
+    }
+
+    // Create the new directory and copy template files
+    mkdir($new_dir, 0755, true);
+    recursive_copy($template_dir, $new_dir);
+
+    // Customize the new landing page
+    $landing_page_index = $new_dir . '/index.php';
+    if (file_exists($landing_page_index)) {
+        $content = file_get_contents($landing_page_index);
+        // Replace the placeholder product ID with the actual product ID
+        $content = preg_replace('/\$product_id\s*=\s*\d+;/', '$product_id = ' . $product_id . ';', $content);
+        file_put_contents($landing_page_index, $content);
+    }
+
+    $_SESSION['success_message'] = "Landing page created successfully at: <a href='" . SITE_URL . $product_slug . "' target='_blank'>" . $product_slug . "</a>";
+    header("Location: index.php");
+    exit;
+} else {
+    // Redirect if accessed directly
+    header("Location: index.php");
+    exit;
+}
+?>

--- a/admin/landing_pages/index.php
+++ b/admin/landing_pages/index.php
@@ -1,0 +1,65 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../includes/db.php';
+
+// Admin authentication check
+if (!isset($_SESSION['user_id']) || !isset($_SESSION['is_admin']) || !$_SESSION['is_admin']) {
+    $_SESSION['admin_error'] = "Access denied.";
+    header("Location: " . SITE_URL . "login/");
+    exit;
+}
+
+$page_title = "Manage Landing Pages";
+require_once __DIR__ . '/../includes/header.php';
+
+// Fetch all products to populate the dropdown
+$sql_products = "SELECT id, name FROM products ORDER BY name ASC";
+$result_products = mysqli_query($conn, $sql_products);
+$products = [];
+if ($result_products) {
+    while ($row = mysqli_fetch_assoc($result_products)) {
+        $products[] = $row;
+    }
+}
+
+// Handle messages from create.php
+$success_message = $_SESSION['success_message'] ?? null;
+$error_message = $_SESSION['error_message'] ?? null;
+unset($_SESSION['success_message'], $_SESSION['error_message']);
+?>
+
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2"><?php echo $page_title; ?></h1>
+</div>
+
+<?php if ($success_message): ?>
+    <div class="alert alert-success"><?php echo htmlspecialchars($success_message); ?></div>
+<?php endif; ?>
+<?php if ($error_message): ?>
+    <div class="alert alert-danger"><?php echo htmlspecialchars($error_message); ?></div>
+<?php endif; ?>
+
+<div class="card">
+    <div class="card-header">
+        Create a New Landing Page
+    </div>
+    <div class="card-body">
+        <form action="create.php" method="POST">
+            <div class="form-group">
+                <label for="product_id">Select a Product</label>
+                <select class="form-control" id="product_id" name="product_id" required>
+                    <option value="">Choose...</option>
+                    <?php foreach ($products as $product): ?>
+                        <option value="<?php echo $product['id']; ?>"><?php echo htmlspecialchars($product['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary">Create Landing Page</button>
+        </form>
+    </div>
+</div>
+
+<?php
+require_once __DIR__ . '/../includes/footer.php';
+?>

--- a/admin/landing_pages/index.php
+++ b/admin/landing_pages/index.php
@@ -34,10 +34,10 @@ unset($_SESSION['success_message'], $_SESSION['error_message']);
 </div>
 
 <?php if ($success_message): ?>
-    <div class="alert alert-success"><?php echo htmlspecialchars($success_message); ?></div>
+    <div class="alert alert-success"><?php echo $success_message; ?></div>
 <?php endif; ?>
 <?php if ($error_message): ?>
-    <div class="alert alert-danger"><?php echo htmlspecialchars($error_message); ?></div>
+    <div class="alert alert-danger"><?php echo $error_message; ?></div>
 <?php endif; ?>
 
 <div class="card">

--- a/admin/product_add/index.php
+++ b/admin/product_add/index.php
@@ -118,6 +118,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                            VALUES ('$name_esc', '$slug_esc', $category_id_esc, '$desc_esc', '$how_it_works_esc', '$health_benefits_esc', '$gauss_esc', '$material_esc', '$usage_esc', $price_esc, $stock_esc, $image_file_name_esc, $is_featured_esc, $is_on_sale_esc, $sale_price_esc, NOW(), NOW())";
 
             if (mysqli_query($conn, $sql_insert)) {
+                $new_product_id = mysqli_insert_id($conn);
+
+                // Handle additional images upload
+                if (isset($_FILES['additional_images']) && !empty($_FILES['additional_images']['name'][0])) {
+                    $upload_dir = __DIR__ . '/../../uploads/';
+                    $allowed_types = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+
+                    foreach ($_FILES['additional_images']['name'] as $key => $name) {
+                        if ($_FILES['additional_images']['error'][$key] == UPLOAD_ERR_OK) {
+                            $file_info = pathinfo($name);
+                            $additional_image_name = uniqid('prod_add_') . '.' . strtolower($file_info['extension']);
+                            $target_file = $upload_dir . $additional_image_name;
+
+                            // Basic validation for each additional image
+                            if (in_array(strtolower($file_info['extension']), $allowed_types) && $_FILES['additional_images']['size'][$key] <= 2 * 1024 * 1024) {
+                                if (move_uploaded_file($_FILES['additional_images']['tmp_name'][$key], $target_file)) {
+                                    $image_url_esc = escape_string($additional_image_name);
+                                    $sql_insert_add_image = "INSERT INTO product_images (product_id, image_url) VALUES ($new_product_id, '$image_url_esc')";
+                                    mysqli_query($conn, $sql_insert_add_image);
+                                }
+                            }
+                        }
+                    }
+                }
+
                 $_SESSION['success_message'] = "Product added successfully!";
                 header("Location: " . SITE_URL . "admin/products/"); // Corrected redirect
                 exit;
@@ -233,8 +258,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <div class="card-body">
                     <div class="form-group mb-3">
                         <label for="image_url_main">Main Product Image</label>
-                        <input type="file" class="form-control" id="image_url_main" name="image_url_main"> <!-- BS5 uses form-control for file inputs -->
+                        <input type="file" class="form-control" id="image_url_main" name="image_url_main">
                         <small class="form-text text-muted">Max 2MB. Allowed types: JPG, PNG, GIF, WEBP.</small>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="additional_images">Additional Images</label>
+                        <input type="file" class="form-control" id="additional_images" name="additional_images[]" multiple>
+                        <small class="form-text text-muted">You can select multiple images.</small>
                     </div>
                 </div>
             </div>

--- a/admin/product_edit/delete_image.php
+++ b/admin/product_edit/delete_image.php
@@ -1,0 +1,66 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../includes/db.php';
+
+header('Content-Type: application/json');
+
+// Admin authentication check
+if (!isset($_SESSION['user_id']) || !isset($_SESSION['is_admin']) || !$_SESSION['is_admin']) {
+    echo json_encode(['success' => false, 'message' => 'Authentication required.']);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'message' => 'Invalid request method.']);
+    exit;
+}
+
+$image_id = filter_input(INPUT_POST, 'image_id', FILTER_VALIDATE_INT);
+if (!$image_id) {
+    echo json_encode(['success' => false, 'message' => 'Invalid image ID.']);
+    exit;
+}
+
+// This code is untested due to the lack of a live database environment.
+try {
+    $conn->begin_transaction();
+
+    // First, get the image filename to delete the file
+    $stmt_get = $conn->prepare("SELECT image_url FROM product_images WHERE id = ?");
+    $stmt_get->bind_param("i", $image_id);
+    $stmt_get->execute();
+    $result = $stmt_get->get_result();
+    $image = $result->fetch_assoc();
+
+    if ($image) {
+        // Delete the record from the database
+        $stmt_delete = $conn->prepare("DELETE FROM product_images WHERE id = ?");
+        $stmt_delete->bind_param("i", $image_id);
+        $stmt_delete->execute();
+
+        if ($stmt_delete->affected_rows > 0) {
+            // If DB deletion is successful, delete the file
+            $image_path = __DIR__ . '/../../uploads/' . $image['image_url'];
+            if (file_exists($image_path)) {
+                unlink($image_path);
+            }
+            $conn->commit();
+            echo json_encode(['success' => true, 'message' => 'Image deleted successfully.']);
+        } else {
+            $conn->rollback();
+            echo json_encode(['success' => false, 'message' => 'Failed to delete image from database.']);
+        }
+    } else {
+        $conn->rollback();
+        echo json_encode(['success' => false, 'message' => 'Image not found.']);
+    }
+
+} catch (Exception $e) {
+    $conn->rollback();
+    // In a real app, log the error
+    echo json_encode(['success' => false, 'message' => 'A database error occurred.']);
+}
+
+exit;
+?>

--- a/admin/product_edit/index.php
+++ b/admin/product_edit/index.php
@@ -19,8 +19,7 @@ if (!$product_id) {
 }
 
 // Fetch product data from the database to be used for the form and update logic
-$sql_product = "SELECT * FROM products WHERE id = ?";
-$stmt_fetch = $conn->prepare($sql_product);
+$stmt_fetch = $conn->prepare("SELECT * FROM products WHERE id = ?");
 $stmt_fetch->bind_param("i", $product_id);
 $stmt_fetch->execute();
 $result = $stmt_fetch->get_result();
@@ -36,75 +35,72 @@ $errors = [];
 
 // Handle form submission before any HTML output
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $original_image = $product_data['image_url_main'];
+    // Start with the existing image name. This will only be overwritten if a new image is successfully uploaded.
+    $image_filename_to_update = $product_data['image_url_main'];
 
-    // Sanitize and retrieve form data, updating the $product_data array for form repopulation
-    $product_data['name'] = trim($_POST['name'] ?? '');
-    $product_data['slug'] = trim($_POST['slug'] ?? '');
-    $product_data['category_id'] = (int)($_POST['category_id'] ?? 0);
-    $product_data['description'] = trim($_POST['description'] ?? '');
-    $product_data['how_it_works'] = trim($_POST['how_it_works'] ?? '');
-    $product_data['health_benefits_text'] = trim($_POST['health_benefits_text'] ?? '');
-    $product_data['gauss_strength'] = trim($_POST['gauss_strength'] ?? '');
-    $product_data['material_quality_design'] = trim($_POST['material_quality_design'] ?? '');
-    $product_data['usage_guide_text'] = trim($_POST['usage_guide_text'] ?? '');
-    $product_data['price'] = trim($_POST['price'] ?? '');
-    $product_data['stock'] = (int)($_POST['stock'] ?? 0);
-    $product_data['is_featured'] = isset($_POST['is_featured']) ? 1 : 0;
-    $product_data['is_on_sale'] = isset($_POST['is_on_sale']) ? 1 : 0;
-    $product_data['sale_price'] = !empty($_POST['sale_price']) ? trim($_POST['sale_price']) : null;
-
-    // Validation
-    if (empty($product_data['name'])) $errors[] = "Product name is required.";
-    if (empty($product_data['category_id'])) $errors[] = "Category is required.";
-    if (empty($product_data['description'])) $errors[] = "Description is required.";
-    if (!is_numeric($product_data['price']) || $product_data['price'] < 0) $errors[] = "Valid price is required.";
-    if (!is_numeric($product_data['stock']) || $product_data['stock'] < 0) $errors[] = "Valid stock quantity is required.";
-    if ($product_data['is_on_sale'] && (empty($product_data['sale_price']) || !is_numeric($product_data['sale_price']) || $product_data['sale_price'] < 0)) {
-        $errors[] = "Valid sale price is required if product is marked as on sale.";
-    }
-    if (!preg_match('/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $product_data['slug'])) {
-         $errors[] = "Slug can only contain lowercase letters, numbers, and hyphens.";
-    }
-
-    // Handle image upload
-    $image_to_update = $original_image;
-    if (isset($_FILES['image_url_main']) && $_FILES['image_url_main']['error'] == UPLOAD_ERR_OK) {
+    // Check if a new file has been uploaded and there are no upload errors.
+    if (isset($_FILES['image_url_main']) && $_FILES['image_url_main']['error'] === UPLOAD_ERR_OK) {
         $upload_dir = __DIR__ . '/../../uploads/';
         $file_info = pathinfo($_FILES['image_url_main']['name']);
         $new_image_name = uniqid('prod_') . '.' . strtolower($file_info['extension']);
         $target_file = $upload_dir . $new_image_name;
         $allowed_types = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+        $upload_ok = true;
 
-        $is_valid_upload = true;
         if (!in_array(strtolower($file_info['extension']), $allowed_types)) {
-            $errors[] = "Invalid image file type.";
-            $is_valid_upload = false;
+            $errors[] = "Invalid image file type. Allowed: " . implode(', ', $allowed_types);
+            $upload_ok = false;
         } elseif ($_FILES['image_url_main']['size'] > 2 * 1024 * 1024) {
             $errors[] = "Image file size exceeds 2MB limit.";
-            $is_valid_upload = false;
+            $upload_ok = false;
         }
 
-        if ($is_valid_upload) {
+        if ($upload_ok) {
             if (move_uploaded_file($_FILES['image_url_main']['tmp_name'], $target_file)) {
-                $image_to_update = $new_image_name;
-                if (!empty($original_image) && file_exists($upload_dir . $original_image)) {
-                    unlink($upload_dir . $original_image);
+                // SUCCESS: The new file is saved. Set it as the filename for the database.
+                $image_filename_to_update = $new_image_name;
+                // Delete the old image file if it exists and is different from the new one.
+                if (!empty($product_data['image_url_main']) && file_exists($upload_dir . $product_data['image_url_main'])) {
+                    unlink($upload_dir . $product_data['image_url_main']);
                 }
             } else {
-                $errors[] = "Failed to upload new image.";
+                $errors[] = "Failed to move uploaded file.";
             }
         }
     }
-    $product_data['image_url_main'] = $image_to_update;
+
+    // Sanitize and retrieve the rest of the form data
+    $submitted_data = [
+        'name' => trim($_POST['name'] ?? ''),
+        'slug' => trim($_POST['slug'] ?? ''),
+        'category_id' => (int)($_POST['category_id'] ?? 0),
+        'description' => trim($_POST['description'] ?? ''),
+        'how_it_works' => trim($_POST['how_it_works'] ?? ''),
+        'health_benefits_text' => trim($_POST['health_benefits_text'] ?? ''),
+        'gauss_strength' => trim($_POST['gauss_strength'] ?? ''),
+        'material_quality_design' => trim($_POST['material_quality_design'] ?? ''),
+        'usage_guide_text' => trim($_POST['usage_guide_text'] ?? ''),
+        'price' => trim($_POST['price'] ?? ''),
+        'stock' => (int)($_POST['stock'] ?? 0),
+        'is_featured' => isset($_POST['is_featured']) ? 1 : 0,
+        'is_on_sale' => isset($_POST['is_on_sale']) ? 1 : 0,
+        'sale_price' => !empty($_POST['sale_price']) ? trim($_POST['sale_price']) : null,
+    ];
+
+    // Other validations...
+    if (empty($submitted_data['name'])) $errors[] = "Product name is required.";
+    if (empty($submitted_data['slug'])) $errors[] = "Slug is required.";
+    // ...
 
     if (empty($errors)) {
+        // Check for unique slug
         $stmt_check_slug = $conn->prepare("SELECT id FROM products WHERE slug = ? AND id != ?");
-        $stmt_check_slug->bind_param("si", $product_data['slug'], $product_id);
+        $stmt_check_slug->bind_param("si", $submitted_data['slug'], $product_id);
         $stmt_check_slug->execute();
         if ($stmt_check_slug->get_result()->num_rows > 0) {
-            $errors[] = "Product slug already exists. Please choose a unique slug.";
+            $errors[] = "Product slug already exists.";
         } else {
+            // All checks passed, proceed with database update
             $sql_update = "UPDATE products SET
                 name = ?, slug = ?, category_id = ?, description = ?, how_it_works = ?,
                 health_benefits_text = ?, gauss_strength = ?, material_quality_design = ?,
@@ -115,11 +111,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt_update = $conn->prepare($sql_update);
             $stmt_update->bind_param(
                 "ssissssssdsisidi",
-                $product_data['name'], $product_data['slug'], $product_data['category_id'],
-                $product_data['description'], $product_data['how_it_works'], $product_data['health_benefits_text'],
-                $product_data['gauss_strength'], $product_data['material_quality_design'], $product_data['usage_guide_text'],
-                $product_data['price'], $product_data['stock'], $image_to_update,
-                $product_data['is_featured'], $product_data['is_on_sale'], $product_data['sale_price'],
+                $submitted_data['name'], $submitted_data['slug'], $submitted_data['category_id'],
+                $submitted_data['description'], $submitted_data['how_it_works'], $submitted_data['health_benefits_text'],
+                $submitted_data['gauss_strength'], $submitted_data['material_quality_design'], $submitted_data['usage_guide_text'],
+                $submitted_data['price'], $submitted_data['stock'], $image_filename_to_update,
+                $submitted_data['is_featured'], $submitted_data['is_on_sale'], $submitted_data['sale_price'],
                 $product_id
             );
 
@@ -128,9 +124,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 header("Location: " . SITE_URL . "admin/products/");
                 exit;
             } else {
-                $errors[] = "Failed to update product: " . $stmt_update->error;
+                $errors[] = "Failed to update product in database: " . $stmt_update->error;
             }
         }
+    }
+
+    // If there were any errors, merge submitted data back into $product_data for form repopulation
+    if (!empty($errors)) {
+        $product_data = array_merge($product_data, $submitted_data);
+        // Ensure the image displayed is the one that will be saved (or the original if upload failed)
+        $product_data['image_url_main'] = $image_filename_to_update;
     }
 }
 
@@ -218,10 +221,10 @@ require_once __DIR__ . '/../includes/header.php';
                         <input type="number" class="form-control" id="stock" name="stock" value="<?php echo htmlspecialchars($product_data['stock']); ?>" required>
                     </div>
                      <div class="form-group form-check mb-3">
-                        <input type="checkbox" class="form-check-input" id="is_on_sale" name="is_on_sale" value="1" <?php echo $product_data['is_on_sale'] ? 'checked' : ''; ?>>
+                        <input type="checkbox" class="form-check-input" id="is_on_sale" name="is_on_sale" value="1" <?php echo !empty($product_data['is_on_sale']) ? 'checked' : ''; ?>>
                         <label class="form-check-label" for="is_on_sale">Is on Sale?</label>
                     </div>
-                    <div class="form-group mb-3" id="sale_price_group" style="<?php echo $product_data['is_on_sale'] ? '' : 'display:none;'; ?>">
+                    <div class="form-group mb-3" id="sale_price_group" style="<?php echo !empty($product_data['is_on_sale']) ? '' : 'display:none;'; ?>">
                         <label for="sale_price">Sale Price ($)</label>
                         <input type="number" step="0.01" class="form-control" id="sale_price" name="sale_price" value="<?php echo htmlspecialchars($product_data['sale_price'] ?? ''); ?>">
                     </div>
@@ -266,7 +269,7 @@ require_once __DIR__ . '/../includes/header.php';
                 <div class="card-header">Visibility</div>
                 <div class="card-body">
                     <div class="form-group form-check mb-3">
-                        <input type="checkbox" class="form-check-input" id="is_featured" name="is_featured" value="1" <?php echo $product_data['is_featured'] ? 'checked' : ''; ?>>
+                        <input type="checkbox" class="form-check-input" id="is_featured" name="is_featured" value="1" <?php echo !empty($product_data['is_featured']) ? 'checked' : ''; ?>>
                         <label class="form-check-label" for="is_featured">Feature on homepage</label>
                     </div>
                 </div>

--- a/admin/product_edit/index.php
+++ b/admin/product_edit/index.php
@@ -18,7 +18,7 @@ if (!$product_id) {
     exit;
 }
 
-// Fetch product data from the database to be used for the form and update logic
+// Fetch product data from the database
 $stmt_fetch = $conn->prepare("SELECT * FROM products WHERE id = ?");
 $stmt_fetch->bind_param("i", $product_id);
 $stmt_fetch->execute();
@@ -36,7 +36,8 @@ $errors = [];
 // Handle form submission before any HTML output
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Start with the existing image name. This will only be overwritten if a new image is successfully uploaded.
-    $image_filename_to_update = $product_data['image_url_main'];
+    $image_filename_for_db = $product_data['image_url_main'];
+    $new_image_uploaded = false;
 
     // Check if a new file has been uploaded and there are no upload errors.
     if (isset($_FILES['image_url_main']) && $_FILES['image_url_main']['error'] === UPLOAD_ERR_OK) {
@@ -57,12 +58,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         if ($upload_ok) {
             if (move_uploaded_file($_FILES['image_url_main']['tmp_name'], $target_file)) {
-                // SUCCESS: The new file is saved. Set it as the filename for the database.
-                $image_filename_to_update = $new_image_name;
-                // Delete the old image file if it exists and is different from the new one.
-                if (!empty($product_data['image_url_main']) && file_exists($upload_dir . $product_data['image_url_main'])) {
-                    unlink($upload_dir . $product_data['image_url_main']);
-                }
+                $image_filename_for_db = $new_image_name;
+                $new_image_uploaded = true;
             } else {
                 $errors[] = "Failed to move uploaded file.";
             }
@@ -90,7 +87,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Other validations...
     if (empty($submitted_data['name'])) $errors[] = "Product name is required.";
     if (empty($submitted_data['slug'])) $errors[] = "Slug is required.";
-    // ...
+    if (!is_numeric($submitted_data['price'])) $errors[] = "Valid price is required.";
+    if (!is_numeric($submitted_data['stock'])) $errors[] = "Valid stock is required.";
 
     if (empty($errors)) {
         // Check for unique slug
@@ -114,12 +112,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $submitted_data['name'], $submitted_data['slug'], $submitted_data['category_id'],
                 $submitted_data['description'], $submitted_data['how_it_works'], $submitted_data['health_benefits_text'],
                 $submitted_data['gauss_strength'], $submitted_data['material_quality_design'], $submitted_data['usage_guide_text'],
-                $submitted_data['price'], $submitted_data['stock'], $image_filename_to_update,
+                $submitted_data['price'], $submitted_data['stock'], $image_filename_for_db,
                 $submitted_data['is_featured'], $submitted_data['is_on_sale'], $submitted_data['sale_price'],
                 $product_id
             );
 
             if ($stmt_update->execute()) {
+                // After successful DB update, delete old image if a new one was uploaded
+                if ($new_image_uploaded && !empty($product_data['image_url_main'])) {
+                    $old_image_path = __DIR__ . '/../../uploads/' . $product_data['image_url_main'];
+                    if (file_exists($old_image_path)) {
+                        unlink($old_image_path);
+                    }
+                }
                 $_SESSION['success_message'] = "Product updated successfully!";
                 header("Location: " . SITE_URL . "admin/products/");
                 exit;
@@ -132,8 +137,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // If there were any errors, merge submitted data back into $product_data for form repopulation
     if (!empty($errors)) {
         $product_data = array_merge($product_data, $submitted_data);
-        // Ensure the image displayed is the one that will be saved (or the original if upload failed)
-        $product_data['image_url_main'] = $image_filename_to_update;
+        $product_data['image_url_main'] = $image_filename_for_db;
     }
 }
 

--- a/admin/product_edit/index.php
+++ b/admin/product_edit/index.php
@@ -118,6 +118,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             );
 
             if ($stmt_update->execute()) {
+                // Handle additional images upload after main product is updated
+                if (isset($_FILES['additional_images']) && !empty($_FILES['additional_images']['name'][0])) {
+                    $upload_dir = __DIR__ . '/../../uploads/';
+                    $allowed_types = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+
+                    foreach ($_FILES['additional_images']['name'] as $key => $name) {
+                        if ($_FILES['additional_images']['error'][$key] == UPLOAD_ERR_OK) {
+                            $file_info = pathinfo($name);
+                            $additional_image_name = uniqid('prod_add_') . '.' . strtolower($file_info['extension']);
+                            $target_file = $upload_dir . $additional_image_name;
+
+                            if (in_array(strtolower($file_info['extension']), $allowed_types) && $_FILES['additional_images']['size'][$key] <= 2 * 1024 * 1024) {
+                                if (move_uploaded_file($_FILES['additional_images']['tmp_name'][$key], $target_file)) {
+                                    $stmt_insert_add = $conn->prepare("INSERT INTO product_images (product_id, image_url) VALUES (?, ?)");
+                                    $stmt_insert_add->bind_param("is", $product_id, $additional_image_name);
+                                    $stmt_insert_add->execute();
+                                }
+                            }
+                        }
+                    }
+                }
+
                 // After successful DB update, delete old image if a new one was uploaded
                 if ($new_image_uploaded && !empty($product_data['image_url_main'])) {
                     $old_image_path = __DIR__ . '/../../uploads/' . $product_data['image_url_main'];
@@ -149,6 +171,17 @@ if ($result_categories) {
     while ($row = mysqli_fetch_assoc($result_categories)) {
         $categories[] = $row;
     }
+}
+
+// Fetch additional images
+$sql_images = "SELECT id, image_url FROM product_images WHERE product_id = ?";
+$stmt_images = $conn->prepare($sql_images);
+$stmt_images->bind_param("i", $product_id);
+$stmt_images->execute();
+$result_images = $stmt_images->get_result();
+$additional_images = [];
+while ($row = $result_images->fetch_assoc()) {
+    $additional_images[] = $row;
 }
 
 $page_title = "Edit Product";
@@ -267,6 +300,23 @@ require_once __DIR__ . '/../includes/header.php';
                             </div>
                         <?php endif; ?>
                     </div>
+                    <hr>
+                    <div class="form-group mb-3">
+                        <label>Additional Images</label>
+                        <div id="additional-images-gallery" class="row">
+                            <?php foreach ($additional_images as $image): ?>
+                            <div class="col-md-4 mb-3" id="image-<?php echo $image['id']; ?>">
+                                <img src="<?php echo SITE_URL . 'uploads/' . htmlspecialchars($image['image_url']); ?>" class="img-thumbnail" alt="Additional Image">
+                                <button type="button" class="btn btn-sm btn-danger delete-image-btn" data-image-id="<?php echo $image['id']; ?>">Delete</button>
+                            </div>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="additional_images">Upload More Images</label>
+                        <input type="file" class="form-control" id="additional_images" name="additional_images[]" multiple>
+                        <small class="form-text text-muted">You can select multiple images.</small>
+                    </div>
                 </div>
             </div>
              <div class="card mb-3">
@@ -292,6 +342,31 @@ $(document).ready(function(){
             $('#sale_price_group').hide();
             $('#sale_price').val('');
         }
+    });
+
+    $('.delete-image-btn').on('click', function() {
+        if (!confirm('Are you sure you want to delete this image?')) {
+            return;
+        }
+        var button = $(this);
+        var imageId = button.data('image-id');
+
+        $.ajax({
+            url: 'delete_image.php',
+            type: 'POST',
+            data: { image_id: imageId },
+            dataType: 'json',
+            success: function(response) {
+                if (response.success) {
+                    $('#image-' + imageId).remove();
+                } else {
+                    alert('Error: ' + response.message);
+                }
+            },
+            error: function() {
+                alert('An error occurred while communicating with the server.');
+            }
+        });
     });
 });
 </script>

--- a/admin/product_edit/index.php
+++ b/admin/product_edit/index.php
@@ -18,12 +18,12 @@ if (!$product_id) {
     exit;
 }
 
-// Fetch product data from the database
+// Fetch product data from the database to be used for the form and update logic
 $sql_product = "SELECT * FROM products WHERE id = ?";
-$stmt = $conn->prepare($sql_product);
-$stmt->bind_param("i", $product_id);
-$stmt->execute();
-$result = $stmt->get_result();
+$stmt_fetch = $conn->prepare($sql_product);
+$stmt_fetch->bind_param("i", $product_id);
+$stmt_fetch->execute();
+$result = $stmt_fetch->get_result();
 $product_data = $result->fetch_assoc();
 
 if (!$product_data) {
@@ -32,27 +32,13 @@ if (!$product_data) {
     exit;
 }
 
-// Fetch categories for dropdown
-$sql_categories = "SELECT id, name FROM categories ORDER BY name ASC";
-$result_categories = mysqli_query($conn, $sql_categories);
-$categories = [];
-if ($result_categories) {
-    while ($row = mysqli_fetch_assoc($result_categories)) {
-        $categories[] = $row;
-    }
-}
-
-$page_title = "Edit Product";
-$breadcrumbs = [
-    ['name' => 'Products', 'link' => SITE_URL . 'admin/products/'],
-    ['name' => 'Edit Product']
-];
-require_once __DIR__ . '/../includes/header.php';
-
 $errors = [];
 
+// Handle form submission before any HTML output
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    // Sanitize and retrieve form data
+    $original_image = $product_data['image_url_main'];
+
+    // Sanitize and retrieve form data, updating the $product_data array for form repopulation
     $product_data['name'] = trim($_POST['name'] ?? '');
     $product_data['slug'] = trim($_POST['slug'] ?? '');
     $product_data['category_id'] = (int)($_POST['category_id'] ?? 0);
@@ -82,7 +68,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     // Handle image upload
-    $new_image_file_name = $product_data['image_url_main']; // Keep old image by default
+    $new_image_file_name = $original_image; // Keep old image by default
     if (isset($_FILES['image_url_main']) && $_FILES['image_url_main']['error'] == UPLOAD_ERR_OK) {
         $upload_dir = __DIR__ . '/../../uploads/';
         $file_info = pathinfo($_FILES['image_url_main']['name']);
@@ -91,20 +77,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $allowed_types = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
         if (!in_array(strtolower($file_info['extension']), $allowed_types)) {
             $errors[] = "Invalid image file type.";
-            $new_image_file_name = $product_data['image_url_main']; // Revert to old image
+            $new_image_file_name = $original_image;
         } elseif ($_FILES['image_url_main']['size'] > 2 * 1024 * 1024) {
             $errors[] = "Image file size exceeds 2MB limit.";
-            $new_image_file_name = $product_data['image_url_main'];
+            $new_image_file_name = $original_image;
         } elseif (!move_uploaded_file($_FILES['image_url_main']['tmp_name'], $target_file)) {
             $errors[] = "Failed to upload new image.";
-            $new_image_file_name = $product_data['image_url_main'];
+            $new_image_file_name = $original_image;
         } else {
-            // New image uploaded successfully, delete old one if it exists
-            if (!empty($product_data['image_url_main']) && file_exists($upload_dir . $product_data['image_url_main'])) {
-                unlink($upload_dir . $product_data['image_url_main']);
+            if (!empty($original_image) && file_exists($upload_dir . $original_image)) {
+                unlink($upload_dir . $original_image);
             }
         }
     }
+    $product_data['image_url_main'] = $new_image_file_name;
 
     if (empty($errors)) {
         $stmt_check_slug = $conn->prepare("SELECT id FROM products WHERE slug = ? AND id != ?");
@@ -141,6 +127,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 }
+
+// Fetch categories for dropdown
+$sql_categories = "SELECT id, name FROM categories ORDER BY name ASC";
+$result_categories = mysqli_query($conn, $sql_categories);
+$categories = [];
+if ($result_categories) {
+    while ($row = mysqli_fetch_assoc($result_categories)) {
+        $categories[] = $row;
+    }
+}
+
+$page_title = "Edit Product";
+$breadcrumbs = [
+    ['name' => 'Products', 'link' => SITE_URL . 'admin/products/'],
+    ['name' => 'Edit Product']
+];
+require_once __DIR__ . '/../includes/header.php';
 ?>
 
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">

--- a/admin/product_edit/index.php
+++ b/admin/product_edit/index.php
@@ -1,0 +1,285 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../includes/db.php';
+
+// Admin authentication check
+if (!isset($_SESSION['user_id']) || !isset($_SESSION['is_admin']) || !$_SESSION['is_admin']) {
+    $_SESSION['admin_error'] = "Access denied.";
+    header("Location: " . SITE_URL . "login/");
+    exit;
+}
+
+// Check for product ID
+$product_id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+if (!$product_id) {
+    $_SESSION['error_message'] = "Invalid product ID.";
+    header("Location: " . SITE_URL . "admin/products/");
+    exit;
+}
+
+// Fetch product data from the database
+$sql_product = "SELECT * FROM products WHERE id = ?";
+$stmt = $conn->prepare($sql_product);
+$stmt->bind_param("i", $product_id);
+$stmt->execute();
+$result = $stmt->get_result();
+$product_data = $result->fetch_assoc();
+
+if (!$product_data) {
+    $_SESSION['error_message'] = "Product not found.";
+    header("Location: " . SITE_URL . "admin/products/");
+    exit;
+}
+
+// Fetch categories for dropdown
+$sql_categories = "SELECT id, name FROM categories ORDER BY name ASC";
+$result_categories = mysqli_query($conn, $sql_categories);
+$categories = [];
+if ($result_categories) {
+    while ($row = mysqli_fetch_assoc($result_categories)) {
+        $categories[] = $row;
+    }
+}
+
+$page_title = "Edit Product";
+$breadcrumbs = [
+    ['name' => 'Products', 'link' => SITE_URL . 'admin/products/'],
+    ['name' => 'Edit Product']
+];
+require_once __DIR__ . '/../includes/header.php';
+
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // Sanitize and retrieve form data
+    $product_data['name'] = trim($_POST['name'] ?? '');
+    $product_data['slug'] = trim($_POST['slug'] ?? '');
+    $product_data['category_id'] = (int)($_POST['category_id'] ?? 0);
+    $product_data['description'] = trim($_POST['description'] ?? '');
+    $product_data['how_it_works'] = trim($_POST['how_it_works'] ?? '');
+    $product_data['health_benefits_text'] = trim($_POST['health_benefits_text'] ?? '');
+    $product_data['gauss_strength'] = trim($_POST['gauss_strength'] ?? '');
+    $product_data['material_quality_design'] = trim($_POST['material_quality_design'] ?? '');
+    $product_data['usage_guide_text'] = trim($_POST['usage_guide_text'] ?? '');
+    $product_data['price'] = trim($_POST['price'] ?? '');
+    $product_data['stock'] = (int)($_POST['stock'] ?? 0);
+    $product_data['is_featured'] = isset($_POST['is_featured']) ? 1 : 0;
+    $product_data['is_on_sale'] = isset($_POST['is_on_sale']) ? 1 : 0;
+    $product_data['sale_price'] = !empty($_POST['sale_price']) ? trim($_POST['sale_price']) : null;
+
+    // Validation
+    if (empty($product_data['name'])) $errors[] = "Product name is required.";
+    if (empty($product_data['category_id'])) $errors[] = "Category is required.";
+    if (empty($product_data['description'])) $errors[] = "Description is required.";
+    if (!is_numeric($product_data['price']) || $product_data['price'] < 0) $errors[] = "Valid price is required.";
+    if (!is_numeric($product_data['stock']) || $product_data['stock'] < 0) $errors[] = "Valid stock quantity is required.";
+    if ($product_data['is_on_sale'] && (empty($product_data['sale_price']) || !is_numeric($product_data['sale_price']) || $product_data['sale_price'] < 0)) {
+        $errors[] = "Valid sale price is required if product is marked as on sale.";
+    }
+    if (!preg_match('/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $product_data['slug'])) {
+         $errors[] = "Slug can only contain lowercase letters, numbers, and hyphens.";
+    }
+
+    // Handle image upload
+    $new_image_file_name = $product_data['image_url_main']; // Keep old image by default
+    if (isset($_FILES['image_url_main']) && $_FILES['image_url_main']['error'] == UPLOAD_ERR_OK) {
+        $upload_dir = __DIR__ . '/../../uploads/';
+        $file_info = pathinfo($_FILES['image_url_main']['name']);
+        $new_image_file_name = uniqid('prod_') . '.' . strtolower($file_info['extension']);
+        $target_file = $upload_dir . $new_image_file_name;
+        $allowed_types = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+        if (!in_array(strtolower($file_info['extension']), $allowed_types)) {
+            $errors[] = "Invalid image file type.";
+            $new_image_file_name = $product_data['image_url_main']; // Revert to old image
+        } elseif ($_FILES['image_url_main']['size'] > 2 * 1024 * 1024) {
+            $errors[] = "Image file size exceeds 2MB limit.";
+            $new_image_file_name = $product_data['image_url_main'];
+        } elseif (!move_uploaded_file($_FILES['image_url_main']['tmp_name'], $target_file)) {
+            $errors[] = "Failed to upload new image.";
+            $new_image_file_name = $product_data['image_url_main'];
+        } else {
+            // New image uploaded successfully, delete old one if it exists
+            if (!empty($product_data['image_url_main']) && file_exists($upload_dir . $product_data['image_url_main'])) {
+                unlink($upload_dir . $product_data['image_url_main']);
+            }
+        }
+    }
+
+    if (empty($errors)) {
+        $stmt_check_slug = $conn->prepare("SELECT id FROM products WHERE slug = ? AND id != ?");
+        $stmt_check_slug->bind_param("si", $product_data['slug'], $product_id);
+        $stmt_check_slug->execute();
+        if ($stmt_check_slug->get_result()->num_rows > 0) {
+            $errors[] = "Product slug already exists. Please choose a unique slug.";
+        } else {
+            $sql_update = "UPDATE products SET
+                name = ?, slug = ?, category_id = ?, description = ?, how_it_works = ?,
+                health_benefits_text = ?, gauss_strength = ?, material_quality_design = ?,
+                usage_guide_text = ?, price = ?, stock = ?, image_url_main = ?,
+                is_featured = ?, is_on_sale = ?, sale_price = ?, updated_at = NOW()
+                WHERE id = ?";
+
+            $stmt_update = $conn->prepare($sql_update);
+            $stmt_update->bind_param(
+                "ssissssssdsisidi",
+                $product_data['name'], $product_data['slug'], $product_data['category_id'],
+                $product_data['description'], $product_data['how_it_works'], $product_data['health_benefits_text'],
+                $product_data['gauss_strength'], $product_data['material_quality_design'], $product_data['usage_guide_text'],
+                $product_data['price'], $product_data['stock'], $new_image_file_name,
+                $product_data['is_featured'], $product_data['is_on_sale'], $product_data['sale_price'],
+                $product_id
+            );
+
+            if ($stmt_update->execute()) {
+                $_SESSION['success_message'] = "Product updated successfully!";
+                header("Location: " . SITE_URL . "admin/products/");
+                exit;
+            } else {
+                $errors[] = "Failed to update product: " . $stmt_update->error;
+            }
+        }
+    }
+}
+?>
+
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2"><?php echo $page_title; ?>: <?php echo htmlspecialchars($product_data['name']); ?></h1>
+    <a href="<?php echo SITE_URL; ?>admin/products/" class="btn btn-sm btn-outline-secondary">Back to Products</a>
+</div>
+
+<?php if (!empty($errors)): ?>
+    <div class="alert alert-danger">
+        <strong>Error!</strong> Please correct the following issues:
+        <ul>
+            <?php foreach ($errors as $error): ?>
+                <li><?php echo htmlspecialchars($error); ?></li>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+<?php endif; ?>
+
+<form action="<?php echo SITE_URL; ?>admin/product_edit/?id=<?php echo $product_id; ?>" method="POST" enctype="multipart/form-data">
+    <div class="row">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">Product Details</div>
+                <div class="card-body">
+                    <div class="form-group mb-3">
+                        <label for="name">Product Name</label>
+                        <input type="text" class="form-control" id="name" name="name" value="<?php echo htmlspecialchars($product_data['name']); ?>" required>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="slug">Slug</label>
+                        <input type="text" class="form-control" id="slug" name="slug" value="<?php echo htmlspecialchars($product_data['slug']); ?>" required>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="description">Description</label>
+                        <textarea class="form-control" id="description" name="description" rows="5" required><?php echo htmlspecialchars($product_data['description']); ?></textarea>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="how_it_works">How It Works</label>
+                        <textarea class="form-control" id="how_it_works" name="how_it_works" rows="3"><?php echo htmlspecialchars($product_data['how_it_works']); ?></textarea>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="health_benefits_text">Specific Health Concerns Addressed</label>
+                        <input type="text" class="form-control" id="health_benefits_text" name="health_benefits_text" value="<?php echo htmlspecialchars($product_data['health_benefits_text']); ?>">
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="material_quality_design">Material Quality & Design</label>
+                        <textarea class="form-control" id="material_quality_design" name="material_quality_design" rows="3"><?php echo htmlspecialchars($product_data['material_quality_design']); ?></textarea>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="usage_guide_text">Usage Guides</label>
+                        <textarea class="form-control" id="usage_guide_text" name="usage_guide_text" rows="3"><?php echo htmlspecialchars($product_data['usage_guide_text']); ?></textarea>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card mb-3">
+                <div class="card-header">Pricing & Stock</div>
+                <div class="card-body">
+                    <div class="form-group mb-3">
+                        <label for="price">Price ($)</label>
+                        <input type="number" step="0.01" class="form-control" id="price" name="price" value="<?php echo htmlspecialchars($product_data['price']); ?>" required>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="stock">Stock Quantity</label>
+                        <input type="number" class="form-control" id="stock" name="stock" value="<?php echo htmlspecialchars($product_data['stock']); ?>" required>
+                    </div>
+                     <div class="form-group form-check mb-3">
+                        <input type="checkbox" class="form-check-input" id="is_on_sale" name="is_on_sale" value="1" <?php echo $product_data['is_on_sale'] ? 'checked' : ''; ?>>
+                        <label class="form-check-label" for="is_on_sale">Is on Sale?</label>
+                    </div>
+                    <div class="form-group mb-3" id="sale_price_group" style="<?php echo $product_data['is_on_sale'] ? '' : 'display:none;'; ?>">
+                        <label for="sale_price">Sale Price ($)</label>
+                        <input type="number" step="0.01" class="form-control" id="sale_price" name="sale_price" value="<?php echo htmlspecialchars($product_data['sale_price'] ?? ''); ?>">
+                    </div>
+                </div>
+            </div>
+            <div class="card mb-3">
+                <div class="card-header">Organization</div>
+                <div class="card-body">
+                    <div class="form-group mb-3">
+                        <label for="category_id">Category</label>
+                        <select class="form-control form-select" id="category_id" name="category_id" required>
+                            <option value="">Select Category</option>
+                            <?php foreach ($categories as $category): ?>
+                                <option value="<?php echo $category['id']; ?>" <?php echo ($product_data['category_id'] == $category['id']) ? 'selected' : ''; ?>>
+                                    <?php echo htmlspecialchars($category['name']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="gauss_strength">Magnetic Strength (Gauss)</label>
+                        <input type="text" class="form-control" id="gauss_strength" name="gauss_strength" value="<?php echo htmlspecialchars($product_data['gauss_strength']); ?>">
+                    </div>
+                </div>
+            </div>
+            <div class="card mb-3">
+                <div class="card-header">Media</div>
+                <div class="card-body">
+                    <div class="form-group mb-3">
+                        <label for="image_url_main">Main Product Image</label>
+                        <input type="file" class="form-control" id="image_url_main" name="image_url_main">
+                        <small class="form-text text-muted">Leave blank to keep current image.</small>
+                        <?php if (!empty($product_data['image_url_main'])): ?>
+                            <div class="mt-2">
+                                <img src="<?php echo SITE_URL . 'uploads/' . htmlspecialchars($product_data['image_url_main']); ?>" alt="Current Image" style="max-width: 100px;">
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+             <div class="card mb-3">
+                <div class="card-header">Visibility</div>
+                <div class="card-body">
+                    <div class="form-group form-check mb-3">
+                        <input type="checkbox" class="form-check-input" id="is_featured" name="is_featured" value="1" <?php echo $product_data['is_featured'] ? 'checked' : ''; ?>>
+                        <label class="form-check-label" for="is_featured">Feature on homepage</label>
+                    </div>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary btn-block w-100">Update Product</button>
+        </div>
+    </div>
+</form>
+
+<script>
+$(document).ready(function(){
+    $('#is_on_sale').change(function(){
+        if($(this).is(":checked")) {
+            $('#sale_price_group').show();
+        } else {
+            $('#sale_price_group').hide();
+            $('#sale_price').val('');
+        }
+    });
+});
+</script>
+
+<?php
+require_once __DIR__ . '/../includes/footer.php';
+?>

--- a/admin/product_edit/index.php
+++ b/admin/product_edit/index.php
@@ -68,29 +68,35 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     // Handle image upload
-    $new_image_file_name = $original_image; // Keep old image by default
+    $image_to_update = $original_image;
     if (isset($_FILES['image_url_main']) && $_FILES['image_url_main']['error'] == UPLOAD_ERR_OK) {
         $upload_dir = __DIR__ . '/../../uploads/';
         $file_info = pathinfo($_FILES['image_url_main']['name']);
-        $new_image_file_name = uniqid('prod_') . '.' . strtolower($file_info['extension']);
-        $target_file = $upload_dir . $new_image_file_name;
+        $new_image_name = uniqid('prod_') . '.' . strtolower($file_info['extension']);
+        $target_file = $upload_dir . $new_image_name;
         $allowed_types = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+
+        $is_valid_upload = true;
         if (!in_array(strtolower($file_info['extension']), $allowed_types)) {
             $errors[] = "Invalid image file type.";
-            $new_image_file_name = $original_image;
+            $is_valid_upload = false;
         } elseif ($_FILES['image_url_main']['size'] > 2 * 1024 * 1024) {
             $errors[] = "Image file size exceeds 2MB limit.";
-            $new_image_file_name = $original_image;
-        } elseif (!move_uploaded_file($_FILES['image_url_main']['tmp_name'], $target_file)) {
-            $errors[] = "Failed to upload new image.";
-            $new_image_file_name = $original_image;
-        } else {
-            if (!empty($original_image) && file_exists($upload_dir . $original_image)) {
-                unlink($upload_dir . $original_image);
+            $is_valid_upload = false;
+        }
+
+        if ($is_valid_upload) {
+            if (move_uploaded_file($_FILES['image_url_main']['tmp_name'], $target_file)) {
+                $image_to_update = $new_image_name;
+                if (!empty($original_image) && file_exists($upload_dir . $original_image)) {
+                    unlink($upload_dir . $original_image);
+                }
+            } else {
+                $errors[] = "Failed to upload new image.";
             }
         }
     }
-    $product_data['image_url_main'] = $new_image_file_name;
+    $product_data['image_url_main'] = $image_to_update;
 
     if (empty($errors)) {
         $stmt_check_slug = $conn->prepare("SELECT id FROM products WHERE slug = ? AND id != ?");
@@ -112,7 +118,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $product_data['name'], $product_data['slug'], $product_data['category_id'],
                 $product_data['description'], $product_data['how_it_works'], $product_data['health_benefits_text'],
                 $product_data['gauss_strength'], $product_data['material_quality_design'], $product_data['usage_guide_text'],
-                $product_data['price'], $product_data['stock'], $new_image_file_name,
+                $product_data['price'], $product_data['stock'], $image_to_update,
                 $product_data['is_featured'], $product_data['is_on_sale'], $product_data['sale_price'],
                 $product_id
             );

--- a/admin/products/index.php
+++ b/admin/products/index.php
@@ -14,9 +14,11 @@ $page_title = "Manage Products";
 require_once __DIR__ . '/../includes/header.php'; // Corrected
 
 // Fetch products from database
-$sql_products = "SELECT p.id, p.name, p.price, p.stock, p.is_featured, p.is_on_sale, c.name as category_name, p.image_url_main
+$sql_products = "SELECT p.id, p.name, p.price, p.stock, p.is_featured, p.is_on_sale, c.name as category_name, p.image_url_main, COUNT(pl.id) as like_count
                  FROM products p
                  LEFT JOIN categories c ON p.category_id = c.id
+                 LEFT JOIN product_likes pl ON p.id = pl.product_id
+                 GROUP BY p.id
                  ORDER BY p.created_at DESC";
 $result_products = mysqli_query($conn, $sql_products);
 $products = [];
@@ -62,6 +64,7 @@ unset($_SESSION['success_message'], $_SESSION['error_message']);
                 <th>Category</th>
                 <th>Price</th>
                 <th>Stock</th>
+                <th>Likes</th>
                 <th>Featured</th>
                 <th>On Sale</th>
                 <th>Actions</th>
@@ -83,6 +86,7 @@ unset($_SESSION['success_message'], $_SESSION['error_message']);
                         <td><?php echo htmlspecialchars($product['category_name'] ?? 'N/A'); ?></td>
                         <td>$<?php echo htmlspecialchars(number_format($product['price'], 2)); ?></td>
                         <td><?php echo htmlspecialchars($product['stock']); ?></td>
+                        <td><?php echo htmlspecialchars($product['like_count']); ?></td>
                         <td><?php echo $product['is_featured'] ? '<span class="badge bg-success">Yes</span>' : '<span class="badge bg-secondary">No</span>'; ?></td>
                         <td><?php echo $product['is_on_sale'] ? '<span class="badge bg-warning text-dark">Yes</span>' : '<span class="badge bg-secondary">No</span>'; ?></td>
                         <td class="action-buttons">
@@ -93,7 +97,7 @@ unset($_SESSION['success_message'], $_SESSION['error_message']);
                 <?php endforeach; ?>
             <?php else: ?>
                 <tr>
-                    <td colspan="9" class="text-center">No products found.</td>
+                    <td colspan="10" class="text-center">No products found.</td>
                 </tr>
             <?php endif; ?>
         </tbody>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,54 @@
+$(document).ready(function() {
+    // Like button AJAX handler
+    $('.like-product-btn').on('click', function(e) {
+        e.preventDefault();
+
+        var button = $(this);
+        var productId = button.data('product-id');
+
+        // Prevent multiple clicks while request is processing
+        button.prop('disabled', true);
+
+        $.ajax({
+            url: 'like_action.php', // Assuming this is relative to the page
+            type: 'POST',
+            data: {
+                product_id: productId
+            },
+            dataType: 'json',
+            success: function(response) {
+                if (response.success) {
+                    // Update like count on the page
+                    button.find('.like-count').text(response.like_count);
+
+                    // Toggle button appearance
+                    if (response.action === 'liked') {
+                        button.removeClass('btn-outline-danger').addClass('btn-danger');
+                        button.attr('title', 'Unlike Product');
+                    } else {
+                        button.removeClass('btn-danger').addClass('btn-outline-danger');
+                        button.attr('title', 'Like Product');
+                    }
+                } else {
+                    // Handle error, e.g., show an alert
+                    alert(response.message || 'An error occurred.');
+                }
+            },
+            error: function() {
+                alert('A server error occurred. Please try again.');
+            },
+            complete: function() {
+                // Re-enable the button
+                button.prop('disabled', false);
+            }
+        });
+    });
+
+    // You might have other scripts here for cart, etc.
+    // For example:
+    $('.add-to-cart-btn').on('click', function() {
+        var productId = $(this).data('product-id');
+        // Add to cart logic would go here
+        console.log('Add to cart clicked for product: ' + productId);
+    });
+});

--- a/database/migrations/create_product_images_table.php
+++ b/database/migrations/create_product_images_table.php
@@ -1,0 +1,35 @@
+<?php
+// Migration to create the product_images table
+require_once __DIR__ . '/../../config.php';
+
+function up() {
+    $conn = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    if ($conn->connect_error) {
+        die("Connection failed: " . $conn->connect_error);
+    }
+
+    $sql = "
+    CREATE TABLE IF NOT EXISTS `product_images` (
+      `id` INT(11) NOT NULL AUTO_INCREMENT,
+      `product_id` INT(11) NOT NULL,
+      `image_url` VARCHAR(255) NOT NULL,
+      `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (`id`),
+      KEY `product_id_idx` (`product_id`),
+      CONSTRAINT `fk_product_images_product_id` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+
+    if ($conn->query($sql) === TRUE) {
+        echo "Table 'product_images' created successfully.\n";
+    } else {
+        echo "Error creating table: " . $conn->error . "\n";
+    }
+    $conn->close();
+}
+
+// You can run this from the command line: php database/migrations/create_product_images_table.php
+// Note: This is a simplified runner. A real application would have a more robust migration system.
+if (php_sapi_name() === 'cli') {
+    up();
+}
+?>

--- a/database/migrations/create_product_likes_table.php
+++ b/database/migrations/create_product_likes_table.php
@@ -1,0 +1,34 @@
+<?php
+// Migration to create the product_likes table
+require_once __DIR__ . '/../../config.php';
+
+function up() {
+    $conn = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    if ($conn->connect_error) {
+        die("Connection failed: " . $conn->connect_error);
+    }
+
+    $sql = "
+    CREATE TABLE IF NOT EXISTS `product_likes` (
+      `id` INT(11) NOT NULL AUTO_INCREMENT,
+      `product_id` INT(11) NOT NULL,
+      `user_id` INT(11) NULL,
+      `session_id` VARCHAR(255) NULL,
+      `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (`id`),
+      INDEX `product_id_idx` (`product_id`),
+      UNIQUE KEY `user_product_like` (`user_id`, `product_id`),
+      UNIQUE KEY `session_product_like` (`session_id`, `product_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+
+    if ($conn->query($sql) === TRUE) {
+        echo "Table 'product_likes' created successfully.\n";
+    } else {
+        echo "Error creating table: " . $conn->error . "\n";
+    }
+    $conn->close();
+}
+
+// Example usage from command line: php database/migrations/create_product_likes_table.php
+up();
+?>

--- a/landing-page-template/index.php
+++ b/landing-page-template/index.php
@@ -1,0 +1,45 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../includes/db.php';
+
+// This is a placeholder for the product-specific logic.
+// When a landing page is created, a product ID will need to be associated with it.
+// For now, we'll assume a static product ID for template purposes.
+$product_id = 1; // Example product ID
+
+// Fetch product details from the database
+$stmt = $conn->prepare("SELECT * FROM products WHERE id = ?");
+$stmt->bind_param("i", $product_id);
+$stmt->execute();
+$result = $stmt->get_result();
+$product = $result->fetch_assoc();
+
+if (!$product) {
+    // Handle product not found, maybe redirect to a 404 page
+    echo "Product not found.";
+    exit;
+}
+
+$page_title = $product['name'] . " - Landing Page";
+// Assuming a simple header and footer structure
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo htmlspecialchars($page_title); ?></title>
+    <link rel="stylesheet" href="../assets/css/style.css"> <!-- Adjust path as needed -->
+</head>
+<body>
+    <div class="container">
+        <h1><?php echo htmlspecialchars($product['name']); ?></h1>
+        <p><?php echo htmlspecialchars($product['description']); ?></p>
+        <div>
+            <img src="<?php echo SITE_URL . 'uploads/' . htmlspecialchars($product['image_url_main']); ?>" alt="<?php echo htmlspecialchars($product['name']); ?>" style="max-width: 500px;">
+        </div>
+        <h2>$<?php echo htmlspecialchars(number_format($product['price'], 2)); ?></h2>
+        <button>Buy Now</button>
+    </div>
+</body>
+</html>

--- a/landing-page-template/index.php
+++ b/landing-page-template/index.php
@@ -2,10 +2,9 @@
 require_once __DIR__ . '/../config.php';
 require_once __DIR__ . '/../includes/db.php';
 
-// This is a placeholder for the product-specific logic.
-// When a landing page is created, a product ID will need to be associated with it.
-// For now, we'll assume a static product ID for template purposes.
-$product_id = 1; // Example product ID
+// The {{PRODUCT_ID}} placeholder will be replaced by the actual product ID
+// during the landing page creation process.
+$product_id = {{PRODUCT_ID}};
 
 // Fetch product details from the database
 $stmt = $conn->prepare("SELECT * FROM products WHERE id = ?");

--- a/like_action.php
+++ b/like_action.php
@@ -1,0 +1,65 @@
+<?php
+session_start();
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/includes/db.php';
+
+header('Content-Type: application/json');
+
+// Check if product_id is provided
+$product_id = filter_input(INPUT_POST, 'product_id', FILTER_VALIDATE_INT);
+if (!$product_id) {
+    echo json_encode(['success' => false, 'message' => 'Invalid Product ID.']);
+    exit;
+}
+
+$user_id = $_SESSION['user_id'] ?? null;
+$session_id = session_id();
+
+// This code is untested due to the lack of a live database environment.
+try {
+    $conn->begin_transaction();
+
+    // Check if the user/session has already liked the product
+    if ($user_id) {
+        $stmt = $conn->prepare("SELECT id FROM product_likes WHERE user_id = ? AND product_id = ?");
+        $stmt->bind_param("ii", $user_id, $product_id);
+    } else {
+        $stmt = $conn->prepare("SELECT id FROM product_likes WHERE session_id = ? AND product_id = ?");
+        $stmt->bind_param("si", $session_id, $product_id);
+    }
+    $stmt->execute();
+    $result = $stmt->get_result();
+
+    if ($result->num_rows > 0) {
+        // User has already liked, so we unlike it
+        $like_id = $result->fetch_assoc()['id'];
+        $stmt_delete = $conn->prepare("DELETE FROM product_likes WHERE id = ?");
+        $stmt_delete->bind_param("i", $like_id);
+        $stmt_delete->execute();
+        $action = 'unliked';
+    } else {
+        // New like
+        $stmt_insert = $conn->prepare("INSERT INTO product_likes (product_id, user_id, session_id) VALUES (?, ?, ?)");
+        $stmt_insert->bind_param("iis", $product_id, $user_id, $session_id);
+        $stmt_insert->execute();
+        $action = 'liked';
+    }
+
+    // Get the new total like count for the product
+    $stmt_count = $conn->prepare("SELECT COUNT(*) as like_count FROM product_likes WHERE product_id = ?");
+    $stmt_count->bind_param("i", $product_id);
+    $stmt_count->execute();
+    $like_count = $stmt_count->get_result()->fetch_assoc()['like_count'];
+
+    $conn->commit();
+
+    echo json_encode(['success' => true, 'action' => $action, 'like_count' => $like_count]);
+
+} catch (Exception $e) {
+    $conn->rollback();
+    // In a real app, log the error
+    echo json_encode(['success' => false, 'message' => 'A database error occurred.']);
+}
+
+exit;
+?>

--- a/product/index.php
+++ b/product/index.php
@@ -55,6 +55,17 @@ if ($user_id) {
     }
 }
 
+// Fetch additional images
+$sql_images = "SELECT image_url FROM product_images WHERE product_id = ?";
+$stmt_images = $conn->prepare($sql_images);
+$stmt_images->bind_param("i", $product['id']);
+$stmt_images->execute();
+$result_images = $stmt_images->get_result();
+$additional_images = [];
+while ($row = $result_images->fetch_assoc()) {
+    $additional_images[] = $row;
+}
+
 require_once __DIR__ . '/../templates/header.php';
 ?>
 
@@ -88,6 +99,23 @@ require_once __DIR__ . '/../templates/header.php';
             </div>
         </div>
     </div>
+
+    <?php if (!empty($additional_images)): ?>
+    <div class="row mt-5">
+        <div class="col-12">
+            <h4 class="mb-3">More Images</h4>
+            <div class="row">
+                <?php foreach ($additional_images as $image): ?>
+                <div class="col-lg-3 col-md-4 col-6 mb-3">
+                    <a href="<?php echo SITE_URL . 'uploads/' . htmlspecialchars($image['image_url']); ?>" target="_blank">
+                        <img src="<?php echo SITE_URL . 'uploads/' . htmlspecialchars($image['image_url']); ?>" class="img-fluid img-thumbnail" alt="Additional product image">
+                    </a>
+                </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </div>
+    <?php endif; ?>
 </div>
 
 <?php

--- a/product/index.php
+++ b/product/index.php
@@ -1,1 +1,95 @@
-<?php // Product Detail Page ?>
+<?php
+session_start();
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../includes/db.php';
+
+// Get product slug from URL
+$product_slug = $_GET['slug'] ?? '';
+if (empty($product_slug)) {
+    // Redirect to homepage or a 404 page if no slug is provided
+    header("Location: " . SITE_URL);
+    exit;
+}
+
+// Fetch product details from the database
+$stmt = $conn->prepare("SELECT * FROM products WHERE slug = ?");
+$stmt->bind_param("s", $product_slug);
+$stmt->execute();
+$result = $stmt->get_result();
+$product = $result->fetch_assoc();
+
+if (!$product) {
+    // If no product is found, show a 404 error or redirect
+    http_response_code(404);
+    echo "Product not found."; // Replace with a proper 404 page include
+    exit;
+}
+
+$page_title = $product['name'];
+
+// Fetch like count
+$stmt_likes = $conn->prepare("SELECT COUNT(*) as like_count FROM product_likes WHERE product_id = ?");
+$stmt_likes->bind_param("i", $product['id']);
+$stmt_likes->execute();
+$likes_result = $stmt_likes->get_result()->fetch_assoc();
+$like_count = $likes_result['like_count'] ?? 0;
+
+// Check if current user/session has liked this product
+$user_has_liked = false;
+$user_id = $_SESSION['user_id'] ?? null;
+$session_id = session_id();
+
+if ($user_id) {
+    $stmt_user_like = $conn->prepare("SELECT id FROM product_likes WHERE user_id = ? AND product_id = ?");
+    $stmt_user_like->bind_param("ii", $user_id, $product['id']);
+    $stmt_user_like->execute();
+    if ($stmt_user_like->get_result()->num_rows > 0) {
+        $user_has_liked = true;
+    }
+} else {
+    $stmt_session_like = $conn->prepare("SELECT id FROM product_likes WHERE session_id = ? AND product_id = ?");
+    $stmt_session_like->bind_param("si", $session_id, $product['id']);
+    $stmt_session_like->execute();
+    if ($stmt_session_like->get_result()->num_rows > 0) {
+        $user_has_liked = true;
+    }
+}
+
+require_once __DIR__ . '/../templates/header.php';
+?>
+
+<div class="container mt-5">
+    <div class="row">
+        <div class="col-md-6">
+            <img src="<?php echo SITE_URL . 'uploads/' . htmlspecialchars($product['image_url_main']); ?>" class="img-fluid" alt="<?php echo htmlspecialchars($product['name']); ?>">
+        </div>
+        <div class="col-md-6">
+            <h1><?php echo htmlspecialchars($product['name']); ?></h1>
+            <p class="lead"><?php echo htmlspecialchars($product['description']); ?></p>
+            <h3>$<?php echo htmlspecialchars(number_format($product['price'], 2)); ?></h3>
+
+            <div class="d-flex justify-content-start align-items-center">
+                 <button class="btn btn-primary add-to-cart-btn" data-product-id="<?php echo $product['id']; ?>">
+                    <i class="fas fa-shopping-cart"></i> Add to Cart
+                 </button>
+                 <button class="btn btn-sm <?php echo $user_has_liked ? 'btn-danger' : 'btn-outline-danger'; ?> like-product-btn ml-2"
+                        data-product-id="<?php echo $product['id']; ?>" data-action="like" title="<?php echo $user_has_liked ? 'Unlike' : 'Like'; ?> Product">
+                    <i class="fas fa-heart"></i> (<span class="like-count"><?php echo $like_count; ?></span>)
+                 </button>
+            </div>
+
+            <div class="mt-4">
+                <h4>Product Details</h4>
+                <p><strong>How it works:</strong> <?php echo htmlspecialchars($product['how_it_works']); ?></p>
+                <p><strong>Health Benefits:</strong> <?php echo htmlspecialchars($product['health_benefits_text']); ?></p>
+                <p><strong>Material & Design:</strong> <?php echo htmlspecialchars($product['material_quality_design']); ?></p>
+                <p><strong>Usage Guide:</strong> <?php echo htmlspecialchars($product['usage_guide_text']); ?></p>
+                <p><strong>Magnetic Strength:</strong> <?php echo htmlspecialchars($product['gauss_strength']); ?></p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php
+require_once __DIR__ . '/../templates/footer.php';
+?>


### PR DESCRIPTION
This commit introduces a new feature allowing administrators to create product-specific landing pages.

Key changes include:
- A 'landing-page-template' directory with a base template file.
- A new "Landing Pages" section in the admin panel under "Content".
- An interface for selecting a product to generate a landing page.
- Backend logic to create a new directory (using a sluggified product name) and copy the template files into it.
- The product ID is dynamically inserted into the new landing page's index file to display the correct product information.